### PR TITLE
fix context key

### DIFF
--- a/segments.go
+++ b/segments.go
@@ -1,154 +1,153 @@
 package segments
 
 import (
-    "context"
-    "github.com/newrelic/go-agent"
-    "net/http"
+	"context"
+	"github.com/newrelic/go-agent"
+	"net/http"
 )
 
 type Segment interface {
-    End()
-    SetResponse(*http.Response)
+	End()
+	SetResponse(*http.Response)
 }
 
-type NopSegment struct {}
-func (NopSegment) End() {}
+type NopSegment struct{}
+
+func (NopSegment) End()                       {}
 func (NopSegment) SetResponse(*http.Response) {}
 
-
 type NewrelicApplication struct {
-    newrelic newrelic.Application
+	newrelic newrelic.Application
 }
 
-
 func NewNewrelicApplication(name string, key string) (*NewrelicApplication, error) {
-    nr , err := newrelic.NewApplication(newrelic.NewConfig(name, key))
-    if err != nil {
-        return nil, err
-    }
-    return &NewrelicApplication{nr}, nil
+	nr, err := newrelic.NewApplication(newrelic.NewConfig(name, key))
+	if err != nil {
+		return nil, err
+	}
+	return &NewrelicApplication{nr}, nil
 }
 
 func (app *NewrelicApplication) Handler(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-        txn := app.newrelic.StartTransaction(r.URL.Path, w, r)
-        defer txn.End()
+		txn := app.newrelic.StartTransaction(r.URL.Path, w, r)
+		defer txn.End()
 
-        ctx := context.WithValue(r.Context(), "newrelicTransaction", txn)
-        r = r.WithContext(ctx)
+		ctx := context.WithValue(r.Context(), "newrelicTransaction", txn)
+		r = r.WithContext(ctx)
 
-        next.ServeHTTP(w, r)
-    })
+		next.ServeHTTP(w, r)
+	})
 }
 
-type NewrelicDatastoreSegment struct{
-    s newrelic.DatastoreSegment
+type NewrelicDatastoreSegment struct {
+	s newrelic.DatastoreSegment
 }
+
 func (n NewrelicDatastoreSegment) End() {
-    n.s.End()
+	n.s.End()
 }
 func (n NewrelicDatastoreSegment) SetResponse(*http.Response) {}
 
 func StartDatabaseSegment(r *http.Request, table string, operation string) Segment {
-    if r  == nil {
-        return NopSegment{}
-    }
-    ctx := r.Context()
-    newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
+	if r == nil {
+		return NopSegment{}
+	}
+	ctx := r.Context()
+	newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
 
-    if !ok {
-        return NopSegment{}
-    }
+	if !ok {
+		return NopSegment{}
+	}
 
-    return NewrelicDatastoreSegment{newrelic.DatastoreSegment{
-        StartTime:  newrelic.StartSegmentNow(newrelicTransaction),
-        Product:    newrelic.DatastorePostgres,
-        Collection: table,
-        Operation:  operation,
-    }}
+	return NewrelicDatastoreSegment{newrelic.DatastoreSegment{
+		StartTime:  newrelic.StartSegmentNow(newrelicTransaction),
+		Product:    newrelic.DatastorePostgres,
+		Collection: table,
+		Operation:  operation,
+	}}
 }
 
 func StartRedisSegment(r *http.Request, operation string, key string) Segment {
-    if r  == nil {
-        return NopSegment{}
-    }
-    ctx := r.Context()
-    newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
+	if r == nil {
+		return NopSegment{}
+	}
+	ctx := r.Context()
+	newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
 
-    if !ok {
-        return NopSegment{}
-    }
+	if !ok {
+		return NopSegment{}
+	}
 
-    return NewrelicDatastoreSegment{newrelic.DatastoreSegment{
-        StartTime:  newrelic.StartSegmentNow(newrelicTransaction),
-        Product:    newrelic.DatastoreRedis,
-        Operation:  operation,
-        ParameterizedQuery: operation + " " + key,
-        QueryParameters: map[string]interface{}{
-            "key": key,
-        },
-    }}
+	return NewrelicDatastoreSegment{newrelic.DatastoreSegment{
+		StartTime:          newrelic.StartSegmentNow(newrelicTransaction),
+		Product:            newrelic.DatastoreRedis,
+		Operation:          operation,
+		ParameterizedQuery: operation + " " + key,
+		QueryParameters: map[string]interface{}{
+			"key": key,
+		},
+	}}
 }
 
-
-type NewrelicExternalSegment struct{
-    s newrelic.ExternalSegment
+type NewrelicExternalSegment struct {
+	s newrelic.ExternalSegment
 }
+
 func (n NewrelicExternalSegment) End() {
-    n.s.End()
+	n.s.End()
 }
 func (n NewrelicExternalSegment) SetResponse(r *http.Response) {
-    n.s.Response = r
+	n.s.Response = r
 }
 
 func StartExternalSegment(r *http.Request, req *http.Request) Segment {
-    if r  == nil {
-        return NopSegment{}
-    }
-    ctx := r.Context()
-    newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
+	if r == nil {
+		return NopSegment{}
+	}
+	ctx := r.Context()
+	newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
 
-    if !ok {
-        return NopSegment{}
-    }
+	if !ok {
+		return NopSegment{}
+	}
 
-    return NewrelicExternalSegment{newrelic.StartExternalSegment(newrelicTransaction, req)}
+	return NewrelicExternalSegment{newrelic.StartExternalSegment(newrelicTransaction, req)}
 }
 
-
-type NewrelicSegment struct{
-    s newrelic.Segment
+type NewrelicSegment struct {
+	s newrelic.Segment
 }
+
 func (n NewrelicSegment) End() {
-    n.s.End()
+	n.s.End()
 }
 func (n NewrelicSegment) SetResponse(r *http.Response) {}
 
-
 func StartSegment(r *http.Request, name string) Segment {
-    if r  == nil {
-        return NopSegment{}
-    }
-    ctx := r.Context()
-    newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
-    if !ok {
-        return NopSegment{}
-    }
+	if r == nil {
+		return NopSegment{}
+	}
+	ctx := r.Context()
+	newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
+	if !ok {
+		return NopSegment{}
+	}
 
-    return NewrelicSegment{newrelic.StartSegment(newrelicTransaction, name)}
+	return NewrelicSegment{newrelic.StartSegment(newrelicTransaction, name)}
 
 }
 
 func AddAttribute(r *http.Request, key string, value string) {
-    if r  == nil {
-        return
-    }
-    ctx := r.Context()
-    newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
-    if !ok {
-        return
-    }
+	if r == nil {
+		return
+	}
+	ctx := r.Context()
+	newrelicTransaction, ok := ctx.Value("newrelicTransaction").(newrelic.Transaction)
+	if !ok {
+		return
+	}
 
-    newrelicTransaction.AddAttribute(key, value)
+	newrelicTransaction.AddAttribute(key, value)
 }


### PR DESCRIPTION
I need to set the New Relic transaction outside of this library, with the same context key of course, so the functions in `go-segments` can find it.
However, using plain strings as context keys is discouraged and flagged by golint. I'd like to run golint as a pre-commit hook, hence this PR.